### PR TITLE
Fix bounty decoding bug

### DIFF
--- a/internal/bountyservice/rest/bounty.go
+++ b/internal/bountyservice/rest/bounty.go
@@ -2,15 +2,13 @@ package rest
 
 import (
 	"encoding/json"
-	
+
 	"net/http"
 	"strconv"
 	"time"
 
 	db "bounty-poc/internal/bountyservice/repo/postgres"
 	"bounty-poc/internal/bountyservice/service"
-
-
 )
 
 type BountyRequest struct {
@@ -27,12 +25,11 @@ type BountyRequest struct {
 	AssigneeID  int       `json:"assignee_id"`
 }
 
-
 func CreateBounty(w http.ResponseWriter, r *http.Request) {
 
 	bounty := &db.Bounty{}
-	// get body from request and store in object of model bounty
-	err := json.NewDecoder(r.Body).Decode(&bounty)
+	// Decode the request body directly into the bounty struct
+	err := json.NewDecoder(r.Body).Decode(bounty)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -44,4 +41,3 @@ func CreateBounty(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Write([]byte(strconv.Itoa(createdID)))
 }
-

--- a/internal/bountyservice/service/bounty.go
+++ b/internal/bountyservice/service/bounty.go
@@ -2,18 +2,12 @@ package service
 
 import (
 	db "bounty-poc/internal/bountyservice/repo/postgres"
-	//"bounty-poc/pkg/models"
 )
 
-var bs db.BountyService
-//var bounty db.Bounty
-
-
+// CreateBounty persists a new bounty using the repository implementation.
+// The previous implementation used a package level interface variable which
+// could lead to unexpected behaviour when accessed concurrently. Instead we
+// directly call the repository method on the provided bounty instance.
 func CreateBounty(b *db.Bounty) (int, error) {
-	bs = b 
-	id, err := bs.CreateBounty()
-	if err != nil {
-		return id, err
-	}
-	return id, nil
+	return b.CreateBounty()
 }


### PR DESCRIPTION
## Summary
- decode HTTP request bodies into the correct struct
- simplify CreateBounty service helper

## Testing
- `go vet ./...` *(fails: Forbidden - unable to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_684d117645f48331983dcca91cad17ac