### PR TITLE
Add REST handler test

### DIFF
--- a/internal/bountyservice/rest/bounty.go
+++ b/internal/bountyservice/rest/bounty.go
@@ -25,6 +25,8 @@ type BountyRequest struct {
 	AssigneeID  int       `json:"assignee_id"`
 }
 
+var createBounty = service.CreateBounty
+
 func CreateBounty(w http.ResponseWriter, r *http.Request) {
 
 	bounty := &db.Bounty{}
@@ -34,7 +36,7 @@ func CreateBounty(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	createdID, err := service.CreateBounty(bounty)
+	createdID, err := createBounty(bounty)
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return

--- a/internal/bountyservice/rest/bounty_test.go
+++ b/internal/bountyservice/rest/bounty_test.go
@@ -1,0 +1,36 @@
+package rest
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	db "bounty-poc/internal/bountyservice/repo/postgres"
+)
+
+func TestCreateBountySuccess(t *testing.T) {
+	// Mock the service function
+	oldFn := createBounty
+	createBounty = func(b *db.Bounty) (int, error) {
+		return 99, nil
+	}
+	defer func() { createBounty = oldFn }()
+
+	bountyJSON := `{"title":"Test","description":"desc","reward":"stars:2","category":"code","status":"open","deadline":"2024-01-01T00:00:00Z","creator_id":1,"assignee_id":2}`
+
+	req := httptest.NewRequest(http.MethodPost, "/bounty", bytes.NewBufferString(bountyJSON))
+	rec := httptest.NewRecorder()
+
+	CreateBounty(rec, req)
+
+	res := rec.Result()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", res.StatusCode)
+	}
+
+	body := rec.Body.String()
+	if body != "99" {
+		t.Fatalf("expected body 99, got %s", body)
+	}
+}


### PR DESCRIPTION
## Summary
- inject `createBounty` variable so it can be mocked
- add `bounty_test.go` for CreateBounty REST handler

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684d12c932348331852a10819e6b6f83